### PR TITLE
一覧ページの表示系のバグをいくつか修正

### DIFF
--- a/public/css/event-list.css
+++ b/public/css/event-list.css
@@ -30,6 +30,18 @@ a.card-rink {
     float: right;
 }
 
+.card-body .event-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.card-body .map {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .user-info {
     float: right;
 }

--- a/public/css/event-list.css
+++ b/public/css/event-list.css
@@ -3,6 +3,7 @@
 }
 
 .event-box {
+    min-height: 700px;
     margin: 20px;
     padding: 20px;
     border: 1px solid rgba(0, 0, 0, .125);

--- a/public/html/event-list/index.html
+++ b/public/html/event-list/index.html
@@ -49,7 +49,9 @@
             <div class="card-columns">
                 <a class="card-rink" href="#" style="display: none;">
                     <div class="card">
-                        <img class="event-image" src="" alt="card-img-top">
+                        <div class="event-image">
+                            <img class="event-image" src="" alt="イベントイメージ">
+                        </div>
                         <div class="card-body">
                             <p class="card-text held-date"></p>
                             <h4 class="card-text event-name"></h4>

--- a/public/html/event-list/index.html
+++ b/public/html/event-list/index.html
@@ -49,14 +49,14 @@
             <div class="card-columns">
                 <a class="card-rink" href="#" style="display: none;">
                     <div class="card">
-                        <img class="event-image" src="/public/image/test_img1.jpg" alt="card-img-top">
+                        <img class="event-image" src="" alt="card-img-top">
                         <div class="card-body">
-                            <p class="card-text held-date">2020/6/1</p>
-                            <h4 class="card-text event-name">event_title</h4>
-                            <p class="card-text map">三重県亀山市関が丘521-585</p>
+                            <p class="card-text held-date"></p>
+                            <h4 class="card-text event-name"></h4>
+                            <p class="card-text map"></p>
                             <div class="user-info">
-                                <p>user_name</p>
-                                <img class="user-img" src="/public/image/svg/dummy.svg">
+                                <p></p>
+                                <img class="user-img" src="">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
1. イベントタイトルの行数制限
2. 主催地の行数制限
3. イメージ画像が存在しなかったときのイベントカードの大きさ修正
